### PR TITLE
Call setPartsToBody reliably to fix issue #5

### DIFF
--- a/Mail/Message.php
+++ b/Mail/Message.php
@@ -239,6 +239,7 @@ class Message implements \Magento\Framework\Mail\MailMessageInterface{
 	 */
 	public function getRawMessage()
 	{
+		$this->setPartsToBody();
 		return $this->zendMessage->toString();
 	}
 

--- a/Model/MailEvent.php
+++ b/Model/MailEvent.php
@@ -128,7 +128,6 @@ class MailEvent
             foreach ($this->dataHelper->getBccTo($storeId) as $email) {
                 $message->addBcc(trim($email));
             }
-            $message->setPartsToBody();
         }
 
         $this->mail->setTemplateVars(null);


### PR DESCRIPTION
This is a fix for issue #5 (other mails are blank)

For all mail other than order, invoice, shipment, creditmemo (those with attachment) `Mageplaza\EmailAttachments\Mail\Message::setPartsToBody` is never called. That's why those mails don't have a body.

Longer explanation:
Problem is that line 54 from `Mageplaza\EmailAttachments\Observer\AbstractEmail` doesn't get called:

    $this->mail->setTemplateVars($observer->getTransport());

So in turn `Mageplaza\EmailAttachments\Model\Mail::$templateVars` is null which makes `Mageplaza\EmailAttachments\Model\MailEvent` never call `Mageplaza\EmailAttachments\Mail\Message::setPartsToBody` (is only called if observer ran).

So the instance of `Mageplaza\EmailAttachments\Mail\Message` has an element in `$parts` but as `setPartsToBody` never gets called `$zendMessage` never gets a message body.

So in effect all other mails apart from those with attachment don't have a body.