### PR TITLE
Feature: make terms and conditions filename configurable

### DIFF
--- a/Mail/Message.php
+++ b/Mail/Message.php
@@ -239,6 +239,7 @@ class Message implements \Magento\Framework\Mail\MailMessageInterface{
 	 */
 	public function getRawMessage()
 	{
+		$this->setPartsToBody();
 		return $this->zendMessage->toString();
 	}
 

--- a/Model/MailEvent.php
+++ b/Model/MailEvent.php
@@ -128,7 +128,6 @@ class MailEvent
             foreach ($this->dataHelper->getBccTo($storeId) as $email) {
                 $message->addBcc(trim($email));
             }
-            $message->setPartsToBody();
         }
 
         $this->mail->setTemplateVars(null);

--- a/Model/MailEvent.php
+++ b/Model/MailEvent.php
@@ -190,11 +190,13 @@ class MailEvent
     private function setTACAttachment(Message $message, $tacPath)
     {
         list($filePath, $ext, $mimeType) = $this->getTacFile($tacPath);
+        $tacFilename = $this->dataHelper->getConfigGeneral('tac_filename');
+        $tacFilename = ((empty($tacFilename)) ? 'terms_and_conditions' : $tacFilename) . '.'. $ext;
         if($this->dataHelper->versionCompare("2.3")) {
             $attachment = new \Zend_Mime_Part(file_get_contents($filePath));
             $attachment->type = $mimeType;
             $attachment->disposition =  \Zend_Mime::DISPOSITION_ATTACHMENT;
-            $attachment->filename = 'terms_and_conditions.'. $ext;
+            $attachment->filename = $tacFilename;
             return $attachment;
         }
         else{
@@ -203,7 +205,7 @@ class MailEvent
                 $mimeType,
                 \Zend_Mime::DISPOSITION_ATTACHMENT,
                 \Zend_Mime::ENCODING_BASE64,
-                'terms_and_conditions.' . $ext
+                $tacFilename
             );
         }
     }

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -76,6 +76,10 @@
                         <field id="is_enabled_attach_tac">1</field>
                     </depends>
                 </field>
+                <field id="tac_filename" translate="label comment" type="text" sortOrder="90" showInDefault="1" showInWebsite="1" showInStore="1">
+                    <label>Terms and Conditions filename</label>
+                    <comment>Basename for attachment</comment>
+                </field>
             </group>
         </section>
     </system>

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -28,6 +28,7 @@
             </module>
             <general>
                 <enabled>1</enabled>
+                <tac_filename>terms_and_conditions</tac_filename>
             </general>
         </mp_email_attachments>
     </default>


### PR DESCRIPTION
This patch allows the user to adapt the filename that is used for the terms and conditions attachment. If no filename is set a default "terms_and_conditions" is used.
The filename can be set localized per storeview.