### PR TITLE
Fixing UTF-8 encoding for adress list

### DIFF
--- a/etc/di.xml
+++ b/etc/di.xml
@@ -27,5 +27,10 @@
         </arguments>
         <plugin name="mageplaza_emailattachments_transport_factory" type="Mageplaza\EmailAttachments\Mail\TransportFactory"/>
     </type>
+    <type name="Mageplaza\EmailAttachments\Mail\EmailMessage">
+        <arguments>
+            <argument name="encoding" xsi:type="string">utf-8</argument>
+        </arguments>
+    </type>
     <preference for="Magento\Framework\Mail\EmailMessageInterfaceFactory" type="Mageplaza\EmailAttachments\Mail\EmailMessageFactory"/>
 </config>


### PR DESCRIPTION
Fixing a known issue in 2.3.3 where customers with UTF-8 characters in their name or surname will get a failure on email sending feature (tested on reset password).
https://github.com/magento/magento2/issues/24957
