### PR TITLE
Update MailEvent.php

### DIFF
--- a/Model/MailEvent.php
+++ b/Model/MailEvent.php
@@ -128,6 +128,8 @@ class MailEvent
         if (!$this->dataHelper->isEnabled($storeId)) {
             return;
         }
+        
+        $this->parts = [];
 
         if ($emailType = $this->getEmailType($templateVars)) {
             /** @var Order|Invoice|Shipment|Creditmemo $obj */


### PR DESCRIPTION
Fix issue where if emails are sent asynchronously and an error occurs in the first Invoice that's sent, the next Invoice email will contain PDFs from the first Invoice.

### Description
Set $this->parts to default value before attaching PDFs to email.

### Manual testing scenarios
1. Set Magento to send emails asynchronously (https://docs.magento.com/user-guide/configuration/sales/sales-emails.html);
2. Enable attaching Invoice PDFs (path: mp_email_attachments/general/is_enabled_attach_pdf)
3. Create first order by replicating issue in https://github.com/mageplaza/magento-2-email-attachments/pull/18 (for example, use ä (umlaut) in the customer name);
4. Create second order;
5. Invoice first & second orders;
6. Wait for cron to send the emails OR run **sales_send_order_invoice_emails** cron with https://github.com/netz98/n98-magerun2

Without code changes from this PR, the second Invoice email will contain Invoice PDF from the first invoice.
This PR fixes this by setting $this->parts to the initial value.

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
