### PR TITLE
add default encoding value

### DIFF
--- a/Mail/EmailMessage.php
+++ b/Mail/EmailMessage.php
@@ -86,7 +86,7 @@ class EmailMessage
         array $replyTo = null,
         $sender = null,
         $subject = '',
-        $encoding = ''
+        ?string $encoding = 'utf-8'
     ) {
         $this->message = new ZendMessage();
         $mimeMessage = new ZendMimeMessage();


### PR DESCRIPTION
### Description
Fixed an error when the associated name of the email contains a special character [#343](https://github.com/mageplaza/magento-2-smtp/issues/343)

### Fixed Issues (if relevant)
https://github.com/mageplaza/magento-2-smtp/pull/332

### Manual testing scenarios
1. special char in name associate with email
